### PR TITLE
Add GitHub Actions badge for CI workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Djed
 
+[![CI](https://github.com/DjedAlliance/Djed-Solidity/actions/workflows/CI.yml/badge.svg)](https://github.com/DjedAlliance/Djed-Solidity/actions/workflows/CI.yml)
+
 Djed is a formally verified crypto-backed autonomous stablecoin protocol. To learn more, visit the [Djed Alliance's Website](http://www.djed.one).
 
 ## Setting Up


### PR DESCRIPTION
-Include a badge in the README to display the status of the CI workflow.
-This badge helps in quickly identifying if the tests are passing.

Fixes #5 